### PR TITLE
Update KDE Runtime to 6.9

### DIFF
--- a/io.github.hypengw.Qcm.yml
+++ b/io.github.hypengw.Qcm.yml
@@ -1,6 +1,6 @@
 app-id: io.github.hypengw.Qcm
 runtime: org.kde.Platform
-runtime-version: '6.7'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: Qcm
 finish-args:


### PR DESCRIPTION
The current KDE runtime version is end of life.